### PR TITLE
Update @types/cheerio to 0.22.22 and fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -982,9 +982,9 @@
       }
     },
     "@types/cheerio": {
-      "version": "0.22.21",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.21.tgz",
-      "integrity": "sha512-aGI3DfswwqgKPiEOTaiHV2ZPC9KEhprpgEbJnv0fZl3SGX0cGgEva1126dGrMC6AJM6v/aihlUgJn9M5DbDZ/Q==",
+      "version": "0.22.22",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.22.tgz",
+      "integrity": "sha512-05DYX4zU96IBfZFY+t3Mh88nlwSMtmmzSYaQkKN48T495VV1dkHSah6qYyDTN5ngaS0i0VonH37m+RuzSM0YiA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "typings": "dist/index.d.ts",
   "devDependencies": {
-    "@types/cheerio": "^0.22.21",
+    "@types/cheerio": "^0.22.22",
     "@types/jest": "^26.0.14",
     "@types/minimatch": "^3.0.3",
     "@types/webpack": "^4.41.22",

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -61,7 +61,7 @@ describe('HwpAttributesPlugin', (): void => {
 
                 const scripts = $('script');
                 expect(scripts.get()).toHaveLength(3);
-                scripts.each((index, element: CheerioElement): void => {
+                scripts.each((index, element: cheerio.Element): void => {
                     const keys = Object.keys(element.attribs);
                     expect(keys).toContain('src');
                     expect(keys).not.toContain('type');
@@ -106,20 +106,20 @@ describe('HwpAttributesPlugin', (): void => {
                 expect(script2.get()).toHaveLength(1);
                 expect(script3.get()).toHaveLength(1);
 
-                let keys = Object.keys((script1.get(0) as CheerioElement).attribs);
+                let keys = Object.keys((script1.get(0) as cheerio.Element).attribs);
                 expect(keys).toContain('type');
-                expect((script1.get(0) as CheerioElement).attribs['type']).toBe('module');
+                expect((script1.get(0) as cheerio.Element).attribs['type']).toBe('module');
                 expect(keys).not.toContain('nomodule');
                 expect(keys).not.toContain('async');
                 expect(keys).not.toContain('defer');
 
-                keys = Object.keys((script2.get(0) as CheerioElement).attribs);
+                keys = Object.keys((script2.get(0) as cheerio.Element).attribs);
                 expect(keys).not.toContain('type');
                 expect(keys).not.toContain('nomodule');
                 expect(keys).toContain('async');
                 expect(keys).toContain('defer');
 
-                keys = Object.keys((script3.get(0) as CheerioElement).attribs);
+                keys = Object.keys((script3.get(0) as cheerio.Element).attribs);
                 expect(keys).not.toContain('type');
                 expect(keys).toContain('nomodule');
                 expect(keys).not.toContain('async');


### PR DESCRIPTION
Breaking change in @types/cheerio@0.22.22: CheerioElement is now cheerio.Element :-(
